### PR TITLE
Refactor DockerImage to use Okio FileSystem and Path

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.17.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
     implementation("org.apache.commons:commons-compress:1.26.1")
+    implementation("com.squareup.okio:okio-jvm:3.9.0") // Downgraded Okio version
 }
 
 java {

--- a/src/main/java/org/example/Main.kt
+++ b/src/main/java/org/example/Main.kt
@@ -18,7 +18,8 @@ fun main(args: Array<String>) {
     }
 
     try {
-        val editor = DockerImage(tarballPath)
+        // Updated to use the new top-level DockerImage function
+        val editor = DockerImage(tarFile)
 
         println("\n--- Docker Image Configuration ---")
         editor.getConfig()?.let { config ->

--- a/src/test/java/org/example/DockerImageTest.kt
+++ b/src/test/java/org/example/DockerImageTest.kt
@@ -1,166 +1,145 @@
 package org.example
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertTrue
+import okio.FileSystem
+import okio.Path.Companion.toOkioPath
+import okio.buffer
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
-import java.io.FileOutputStream
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry
-import java.io.ByteArrayInputStream
 
 class DockerImageTest {
 
-    private val TEST_TARBALL_PATH = "./test-image.tar"
-    private val TEST_TARBALL_PATH_NEW = "./test-image-new.tar"
-    private val ORIGINAL_MANIFEST_CONTENT = """
-        [
-          {
-            "Config": "config.json",
-            "RepoTags": [
-              "test/image:latest",
-              "test/image:1.0"
-            ],
-            "Layers": [
-              "layer1.tar",
-              "layer2.tar"
-            ]
-          }
-        ]
-    """.trimIndent()
-    private val ORIGINAL_CONFIG_CONTENT = """
-        {
-          "architecture": "amd64",
-          "os": "linux"
-        }
-    """.trimIndent()
+    @TempDir
+    lateinit var tempDir: File
+    private lateinit var testTarballFile: File
+    private val fileSystem = FileSystem.SYSTEM
 
     @BeforeEach
-    fun setup() {
-        // Create a dummy tarball for testing
-        createDummyTarball(TEST_TARBALL_PATH, ORIGINAL_MANIFEST_CONTENT, ORIGINAL_CONFIG_CONTENT)
-    }
+    fun setUp() {
+        testTarballFile = File(tempDir, "test-image.tar")
 
-    @AfterEach
-    fun teardown() {
-        // Clean up the dummy tarball
-        File(TEST_TARBALL_PATH).delete()
-        File(TEST_TARBALL_PATH_NEW).delete()
-    }
+        val manifestContent = """
+            [
+                {
+                    "Config": "config.json",
+                    "RepoTags": ["test-image:latest", "test-image:1.0"],
+                    "Layers": ["layer1.tar.gz"]
+                }
+            ]
+        """.trimIndent()
 
-    private fun createDummyTarball(tarballPath: String, manifestContent: String, configContent: String, layerContent: ByteArray? = null) {
-        TarArchiveOutputStream(FileOutputStream(tarballPath)).use { tarOutput ->
-            // Add manifest.json
-            val manifestEntry = TarArchiveEntry("manifest.json")
-            val manifestBytes = manifestContent.toByteArray(Charsets.UTF_8)
-            manifestEntry.size = manifestBytes.size.toLong()
-            tarOutput.putArchiveEntry(manifestEntry)
-            tarOutput.write(manifestBytes)
-            tarOutput.closeArchiveEntry()
+        val configContent = """
+            {
+                "architecture": "amd64",
+                "os": "linux"
+            }
+        """.trimIndent()
 
-            // Add config.json
-            val configEntry = TarArchiveEntry("config.json")
-            val configBytes = configContent.toByteArray(Charsets.UTF_8)
-            configEntry.size = configBytes.size.toLong()
-            tarOutput.putArchiveEntry(configEntry)
-            tarOutput.write(configBytes)
-            tarOutput.closeArchiveEntry()
+        val layerContent = "This is dummy layer content."
 
-            // Add layer.tar if provided
-            if (layerContent != null) {
-                val layerEntry = TarArchiveEntry("layer.tar")
-                layerEntry.size = layerContent.size.toLong()
-                tarOutput.putArchiveEntry(layerEntry)
-                tarOutput.write(layerContent)
+        val testTarballPath = testTarballFile.toOkioPath()
+        fileSystem.sink(testTarballPath).buffer().outputStream().use { outputStream ->
+            org.apache.commons.compress.archivers.tar.TarArchiveOutputStream(outputStream).use { tarOutput ->
+                var entry = org.apache.commons.compress.archivers.tar.TarArchiveEntry("manifest.json")
+                var bytes = manifestContent.toByteArray(Charsets.UTF_8)
+                entry.size = bytes.size.toLong()
+                tarOutput.putArchiveEntry(entry)
+                tarOutput.write(bytes)
+                tarOutput.closeArchiveEntry()
+
+                entry = org.apache.commons.compress.archivers.tar.TarArchiveEntry("config.json")
+                bytes = configContent.toByteArray(Charsets.UTF_8)
+                entry.size = bytes.size.toLong()
+                tarOutput.putArchiveEntry(entry)
+                tarOutput.write(bytes)
+                tarOutput.closeArchiveEntry()
+
+                entry = org.apache.commons.compress.archivers.tar.TarArchiveEntry("layer1.tar.gz")
+                bytes = layerContent.toByteArray(Charsets.UTF_8)
+                entry.size = bytes.size.toLong()
+                tarOutput.putArchiveEntry(entry)
+                tarOutput.write(bytes)
                 tarOutput.closeArchiveEntry()
             }
         }
     }
 
     @Test
-    fun testGetManifest() {
-        val editor = DockerImage(TEST_TARBALL_PATH)
-        val manifest = editor.getManifest()
+    fun `test DockerImage constructor with FileSystem and Path`() {
+        val image = DockerImage(fileSystem, testTarballFile.toOkioPath())
+        assertNotNull(image.getManifest(), "Manifest should not be null")
+        assertNotNull(image.getConfig(), "Config should not be null")
+    }
+
+    @Test
+    fun `test top-level DockerImage function with java File`() {
+        val image = DockerImage(testTarballFile)
+        assertNotNull(image.getManifest(), "Manifest should not be null")
+        assertNotNull(image.getConfig(), "Config should not be null")
+    }
+
+    @Test
+    fun `getManifest returns correct manifest content`() {
+        val image = DockerImage(testTarballFile)
+        val manifest = image.getManifest()
         assertNotNull(manifest)
         assertTrue(manifest!!.isArray)
         assertEquals(1, manifest.size())
-        assertEquals("config.json", manifest[0]["Config"].asText())
+        assertEquals("config.json", manifest[0]?.get("Config")?.asText())
     }
 
     @Test
-    fun testGetConfig() {
-        val editor = DockerImage(TEST_TARBALL_PATH)
-        val config = editor.getConfig()
+    fun `getConfig returns correct config content`() {
+        val image = DockerImage(testTarballFile)
+        val config = image.getConfig()
         assertNotNull(config)
-        assertEquals("amd64", config!!["architecture"].asText())
-        assertEquals("linux", config["os"].asText())
+        assertEquals("amd64", config?.get("architecture")?.asText())
+        assertEquals("linux", config?.get("os")?.asText())
     }
 
     @Test
-    fun testGetTags() {
-        val editor = DockerImage(TEST_TARBALL_PATH)
-        val tags = editor.getTags()
-        assertEquals(2, tags.size)
-        assertTrue(tags.contains("test/image:latest"))
-        assertTrue(tags.contains("test/image:1.0"))
+    fun `getTags returns correct tags`() {
+        val image = DockerImage(testTarballFile)
+        val tags = image.getTags()
+        assertEquals(listOf("test-image:latest", "test-image:1.0"), tags)
     }
 
     @Test
-    fun testGetLayers() {
-        val editor = DockerImage(TEST_TARBALL_PATH)
-        val layers = editor.getLayers()
-        assertEquals(2, layers.size)
-        assertTrue(layers.contains("layer1.tar"))
-        assertTrue(layers.contains("layer2.tar"))
+    fun `getLayers returns correct layers`() {
+        val image = DockerImage(testTarballFile)
+        val layers = image.getLayers()
+        assertEquals(listOf("layer1.tar.gz"), layers)
     }
 
     @Test
-    fun testSetTags() {
-        val editor = DockerImage(TEST_TARBALL_PATH)
-        val newTags = listOf("new/image:2.0", "new/image:beta")
-        editor.setTags(newTags)
+    fun `setTags updates tags in the tarball`() {
+        val image = DockerImage(testTarballFile)
+        val newTags = listOf("new-image:v1", "new-image:latest")
+        image.setTags(newTags)
 
-        // Re-read the tarball to verify changes
-        val updatedEditor = DockerImage(TEST_TARBALL_PATH)
-        val updatedTags = updatedEditor.getTags()
-        assertEquals(2, updatedTags.size)
-        assertTrue(updatedTags.contains("new/image:2.0"))
-        assertTrue(updatedTags.contains("new/image:beta"))
+        val updatedImage = DockerImage(testTarballFile)
+        assertEquals(newTags, updatedImage.getTags())
+
+        val manifest = updatedImage.getManifest()
+        assertNotNull(manifest)
+        val repoTagsNode = manifest!![0]?.get("RepoTags")
+        assertNotNull(repoTagsNode)
+        assertTrue(repoTagsNode!!.isArray)
+        val tagsList = repoTagsNode.map { it.asText() }
+        assertEquals(newTags, tagsList)
     }
 
     @Test
-    fun testReadImageTagFromTarFile() {
-        val expectedTag = "my-test-image:1.0"
-        val manifestContent = """
-            [
-              {
-                "Config": "config.json",
-                "RepoTags": [
-                  "$expectedTag"
-                ],
-                "Layers": [
-                  "layer.tar"
-                ]
-              }
-            ]
-        """.trimIndent()
-        val configContent = """
-            {
-              "architecture": "amd64",
-              "os": "linux"
-            }
-        """.trimIndent()
-        val layerContent = "This is a dummy layer".toByteArray(Charsets.UTF_8)
-
-        createDummyTarball(TEST_TARBALL_PATH_NEW, manifestContent, configContent, layerContent)
-
-        val editor = DockerImage(TEST_TARBALL_PATH_NEW)
-        val tags = editor.getTags()
-
-        assertEquals(1, tags.size)
-        assertEquals(expectedTag, tags[0])
+    fun `constructor throws IllegalArgumentException for non-existent tarball`() {
+        val nonExistentFile = File(tempDir, "nonexistent.tar")
+        // Ensure the file does not exist before testing
+        if (nonExistentFile.exists()) {
+            nonExistentFile.delete()
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            DockerImage(nonExistentFile)
+        }
     }
 }


### PR DESCRIPTION
- Modified DockerImage constructor to accept Okio FileSystem and Path.
- Added a top-level DockerImage function that takes a java.io.File.
- Updated Main.kt to use the new top-level function.
- Added unit tests for the changes.
- Downgraded Okio to 3.9.0 to resolve Kotlin version incompatibility.