### PR TITLE
Update Kotlin and Okio

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("application")
-    id("org.jetbrains.kotlin.jvm") version "1.9.23"
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
 }
 
 group = "org.example"
@@ -15,12 +15,12 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:2.2.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.17.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
     implementation("org.apache.commons:commons-compress:1.26.1")
-    implementation("com.squareup.okio:okio-jvm:3.9.0") // Downgraded Okio version
+    implementation("com.squareup.okio:okio-jvm:3.15.0")
 }
 
 java {


### PR DESCRIPTION
## Summary
- upgrade `org.jetbrains.kotlin.jvm` plugin to 2.2.0
- bump okio to 3.15.0 and align `kotlin-test-junit5`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686b385346ec832093b3720481295dda