### PR TITLE
Update package path and README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Image Metadata Reader
 
-This Kotlin application reads a Docker image tarball and extracts its metadata, printing it to standard output.
+This Kotlin application reads a Docker image tarball and extracts its metadata, printing it to standard output. The library is provided under the package `tools.kotlin.dockerutils.imageio`.
 
 ## How to Build
 
@@ -23,6 +23,22 @@ To run the application, you need to provide the absolute path to the Docker imag
 Replace `/path/to/your/docker-image.tar` with the actual absolute path to your Docker image tarball (e.g., `/root/hello-world-image.tar`).
 
 The application will then parse the tarball and print the extracted Docker image metadata to your console.
+
+## Getting Started
+
+This snippet demonstrates reading an image stored as a local `tar.gz` archive,
+printing the existing tags and then setting a new tag:
+
+```kotlin
+import java.io.File
+import tools.kotlin.dockerutils.imageio.DockerImage
+
+fun main() {
+    val image = DockerImage(File("/path/to/image.tar.gz"))
+    println("Current tags: ${'$'}{image.getTags()}")
+    image.setTags(listOf("my-image:latest"))
+}
+```
 
 TODO:
 * Modify so DockerImage default constructor takes in an okio Filesystem and Path.  Add a            │

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version "2.2.0"
 }
 
-group = "org.example"
+group = "tools.kotlin.dockerutils.imageio"
 version = "1.0-SNAPSHOT"
 
 repositories {
@@ -34,7 +34,7 @@ kotlin {
 }
 
 application {
-    mainClass.set("org.example.MainKt")
+    mainClass.set("tools.kotlin.dockerutils.imageio.MainKt")
 }
 
 tasks.test {

--- a/src/main/java/tools/kotlin/dockerutils/imageio/DockerImage.kt
+++ b/src/main/java/tools/kotlin/dockerutils/imageio/DockerImage.kt
@@ -1,4 +1,4 @@
-package org.example
+package tools.kotlin.dockerutils.imageio
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/src/main/java/tools/kotlin/dockerutils/imageio/Main.java
+++ b/src/main/java/tools/kotlin/dockerutils/imageio/Main.java
@@ -1,4 +1,4 @@
-package org.example;
+package tools.kotlin.dockerutils.imageio;
 
 //TIP To <b>Run</b> code, press <shortcut actionId="Run"/> or
 // click the <icon src="AllIcons.Actions.Execute"/> icon in the gutter.

--- a/src/main/java/tools/kotlin/dockerutils/imageio/Main.kt
+++ b/src/main/java/tools/kotlin/dockerutils/imageio/Main.kt
@@ -1,6 +1,6 @@
-package org.example
+package tools.kotlin.dockerutils.imageio
 
-import org.example.DockerImage
+import tools.kotlin.dockerutils.imageio.DockerImage
 import java.io.File
 
 fun main(args: Array<String>) {

--- a/src/test/java/tools/kotlin/dockerutils/imageio/DockerImageTest.kt
+++ b/src/test/java/tools/kotlin/dockerutils/imageio/DockerImageTest.kt
@@ -1,4 +1,4 @@
-package org.example
+package tools.kotlin.dockerutils.imageio
 
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath


### PR DESCRIPTION
## Summary
- rename source package to `tools.kotlin.dockerutils.imageio`
- update Gradle group and main class
- add README section showing how to read and modify tags

## Testing
- `./gradlew test --no-daemon`
- `./gradlew build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686b5d922f848320864f54cbcde70168